### PR TITLE
Stack Exchange newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 The best (weekly) newsletters, sorted by topic and date of first issue (oldest first).
 
+## Software Development, General Topics
+
+Title | Archive | RSS | Twitter | Day | 1st Issue | Curator | Publisher
+:--|:--|:--|:--|:--|:--|:--|:--
+[Stack Exchange Newsletters](http://stackexchange.com/newsletters) | - | - | [@stackexchange](https://twitter.com/stackexchange) | - | [July 2011](https://blog.stackexchange.com/2011/07/stack-exchange-site-newsletters/) | - | stack exchange, inc
+
 ## Front End
 
 Title | Archive | RSS | Twitter | Day | 1st Issue | Curator | Publisher


### PR DESCRIPTION
There are some great email [newsletters](http://stackexchange.com/newsletters) from the StackExchange network.

Lots of topics out there ([StackOverflow](http://stackoverflow.com/), [Programmers](http://programmers.stackexchange.com/), [Unix & Linux](http://unix.stackexchange.com/) and many others), so it would probably be problematic to add each one of those separately.
