### PR TITLE
Fix layout for "node module of the week"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Title | Archive | RSS | Twitter | Day | 1st Issue | Curator | Publisher
 :--|:--|:--|:--|:--|:--|:--|:--
 [Node Weekly](http://nodeweekly.com) | [Archive](http://nodeweekly.com/issues) | [RSS](http://nodeweekly.com/rss/1k471e6h) | - | Friday | [August 29, 2013](http://nodeweekly.com/issues/1) | [Peter Cooper](https://twitter.com/peterc) | [Cooper Press](https://cooperpress.com)
 [npm weekly](https://www.npmjs.com/npm-weekly) | [Archive](http://us9.campaign-archive2.com/home/?u=077dfd41302a71310cef619e5&id=e17fe5d778) [Archive](https://medium.com/npm-inc/tagged/npm-weekly) | [RSS](http://us9.campaign-archive2.com/feed?u=077dfd41302a71310cef619e5&id=e17fe5d778) | [@npmjs](https://twitter.com/npmjs) | Thursday | - | - | [npm, Inc.](https://www.npmjs.com/about)
-[node module of the week](http://nmotw.in/subscribe/) | [Archive](https://nmotw.in/) | [RSS](https://nmotw.in/atom.xml) | [@nodemotw](https://twitter.com/nodemotw) | {Thurs|Fri|Sat}day | [](https://nmotw.in/rsvp/) | [Hemanth.HM](https://h3manth.com) | [nmotw.in](https://www.nmotw.in)
+[node module of the week](http://nmotw.in/subscribe/) | [Archive](https://nmotw.in/) | [RSS](https://nmotw.in/atom.xml) | [@nodemotw](https://twitter.com/nodemotw) | {Thurs &#x2016; Fri &#x2016; Sat}day | [](https://nmotw.in/rsvp/) | [Hemanth.HM](https://h3manth.com) | [nmotw.in](https://www.nmotw.in)
 
 ## Android
 


### PR DESCRIPTION
"|" symbol inside cell is breaking template.
And GitHub Markdown parser dont accept `&#124;`.

Before:
<img width="893" alt="screenshot 2017-03-27 19 43 52" src="https://cloud.githubusercontent.com/assets/3439938/24367571/c62256f4-1325-11e7-9172-d1659af99366.png">

After:
<img width="892" alt="screenshot 2017-03-27 20 02 33" src="https://cloud.githubusercontent.com/assets/3439938/24368238/58dfabde-1328-11e7-8bcf-38012c0c7289.png">
